### PR TITLE
Allow files resources to specify git hashes

### DIFF
--- a/src/configLoader.js
+++ b/src/configLoader.js
@@ -27,14 +27,16 @@ function resolveFile(cwd, str) {
         return str;
     }
 
+    let [filePath, hash] = str.split(':');
+
     // if it's already an absolute path, don't do anything
-    if (path.isAbsolute(str)) {
+    if (path.isAbsolute(filePath)) {
         return str;
     }
 
-    if (str.startsWith('.' + path.sep) || str.startsWith('..' + path.sep)) {
+    if (filePath.startsWith('.' + path.sep) || filePath.startsWith('..' + path.sep)) {
         // otherwise, translate to absolute path from relative
-        return path.resolve(cwd, str);
+        return path.resolve(cwd, filePath) + (hash ? ':' + hash : '');
     }
 
     return str;
@@ -110,9 +112,9 @@ function resolveAbsolutePaths(workingDir, configs) {
         if (typeof config.packages === 'object') {
             _.forEach(config.packages, pkg => {
                if (Array.isArray(pkg.code)) {
-                   pkg.code = pkg.code.map(path => fs.existsSync(path) ? resolve(path) : path);
+                   pkg.code = pkg.code.map(path => fs.existsSync(resolve(path).split(':')[0]) ? resolve(path) : path);
                } else if (typeof pkg.code === 'object') {
-                   pkg.code = _.mapValues(pkg.code, path => fs.existsSync(path) ? resolve(path) : path);
+                   pkg.code = _.mapValues(pkg.code, path => fs.existsSync(resolve(path).split(':')[0]) ? resolve(path) : path);
                }
             });
         }

--- a/tests/configLoader.test.js
+++ b/tests/configLoader.test.js
@@ -111,8 +111,10 @@ describe("the configuration loader", () => {
         let configs = getConfig('./fixtures/multiplePubVersion.json');
 
         let codeList = getCodeList(configs).sort();
-        expect(codeList[0]).toMatch('./adUnits.js');
-        expect(codeList[1]).toMatch('./adUnits2.js');
-        expect(codeList[2]).toMatch('digitrust.min.js');
+        expect(codeList[0]).toMatch('fixtures/aTestFile.js:267af7');
+        expect(codeList[1]).toMatch('fixtures/adUnits.js');
+        expect(codeList[2]).toMatch('fixtures/adUnits2.js');
+        expect(codeList[3]).toEqual('console.log(\'hi\');');
+        expect(codeList[4]).toMatch('digitrust.min.js');
     });
 });

--- a/tests/fixtures/aTestFile.js
+++ b/tests/fixtures/aTestFile.js
@@ -1,0 +1,1 @@
+module.exports = "old";

--- a/tests/fixtures/aTestFile.js
+++ b/tests/fixtures/aTestFile.js
@@ -1,1 +1,1 @@
-module.exports = "old";
+module.exports = "new";

--- a/tests/fixtures/multiplePubVersion.json
+++ b/tests/fixtures/multiplePubVersion.json
@@ -35,6 +35,8 @@
         "version": "1.15.0",
         "code": {
           "adUnits": "./adUnits2.js",
+          "aTestFile": "./aTestFile.js:267af7",
+          "javascript": "console.log('hi');",
           "digitrust": "http://cdn.digitru.st/prod/1/digitrust.min.js"
         }
       }


### PR DESCRIPTION
When including a file, a hash can be specified (e.g. `b33fc4:./adUnits.js`) and if the packager is being ran within a git repository will load the file at that version.